### PR TITLE
feat: extend description extraction with Returns keyword

### DIFF
--- a/pkg/generator/templates/entities.html
+++ b/pkg/generator/templates/entities.html
@@ -185,7 +185,7 @@
 				{{if .Example}}
 				<h3 class="font-bold mt-4 mb-2">Example:</h3>
 				<pre
-					class="bg-gray-800 dark:bg-gray-700 p-4 rounded-lg overflow-x-auto"><code class="language-go">{{.Example}}</code></pre>
+					class="bg-gray-800 dark:bg-gray-700 p-4 rounded-lg overflow-x-auto"><code class="hljs language-go">{{.Example}}</code></pre>
 				{{end}}
 
 				{{if .Notes}}
@@ -242,7 +242,7 @@
 					<summary class="cursor-pointer font-semibold text-blue-600 dark:text-blue-400">Show/Hide Function
 						Body</summary>
 					<pre
-						class="mt-2 bg-gray-800 dark:bg-gray-700 p-4 rounded-lg overflow-x-auto"><code class="language-go">{{.Body}}</code></pre>
+						class="mt-2 bg-gray-800 dark:bg-gray-700 p-4 rounded-lg overflow-x-auto"><code class="hljs language-go">{{.Body}}</code></pre>
 				</details>
 				{{end}}
 
@@ -305,7 +305,7 @@
 						{{if .Example}}
 						<h3 class="font-bold mt-4 mb-2">Example:</h3>
 						<pre
-							class="bg-gray-800 dark:bg-gray-700 p-4 rounded-lg overflow-x-auto"><code class="language-go">{{.Example}}</code></pre>
+							class="bg-gray-800 dark:bg-gray-700 p-4 rounded-lg overflow-x-auto"><code class="hljs language-go">{{.Example}}</code></pre>
 						{{end}}
 
 						{{if .Notes}}
@@ -340,7 +340,7 @@
 							<summary class="cursor-pointer font-semibold text-blue-600 dark:text-blue-400">Show/Hide
 								Method Body</summary>
 							<pre
-								class="mt-2 bg-gray-800 dark:bg-gray-700 p-4 rounded-lg overflow-x-auto"><code class="language-go">{{.Body}}</code></pre>
+								class="mt-2 bg-gray-800 dark:bg-gray-700 p-4 rounded-lg overflow-x-auto"><code class="hljs language-go">{{.Body}}</code></pre>
 						</details>
 						{{end}}
 
@@ -405,7 +405,7 @@
 
 				<h3 class="font-bold mt-4 mb-2">Import example:</h3>
 				<pre
-					class="bg-gray-800 dark:bg-gray-700 p-4 rounded-lg overflow-x-auto"><code class="language-go">import "{{.Path}}"</code></pre>
+					class="bg-gray-800 dark:bg-gray-700 p-4 rounded-lg overflow-x-auto"><code class="hljs language-go">import "{{.Path}}"</code></pre>
 
 				{{if .Alias}}
 				<h3 class="font-bold mt-4 mb-2">Imported as:</h3>

--- a/pkg/parser/utils.go
+++ b/pkg/parser/utils.go
@@ -56,6 +56,7 @@ type DescriptionData struct {
 	Example         string
 	Notes           string
 	DeprecationNote string
+	Returns         string
 
 	// Raw fields
 	DescriptionRaw     string
@@ -71,15 +72,18 @@ func extractDescriptionData(doc string) DescriptionData {
 	var exampleLines []string
 	var notesLines []string
 	var deprecationNoteLines []string
+	var returnsLines []string
 
 	var description string
 	var example string
 	var notes string
 	var deprecationNote string
+	var returns string
 
 	isExample := false
 	isNotes := false
 	isDeprecationNote := false
+	isReturns := false
 
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
@@ -87,18 +91,28 @@ func extractDescriptionData(doc string) DescriptionData {
 			isExample = true
 			isNotes = false
 			isDeprecationNote = false
+			isReturns = false
 			continue
 		}
 		if strings.HasPrefix(line, "Notes:") {
 			isNotes = true
 			isExample = false
 			isDeprecationNote = false
+			isReturns = false
 			continue
 		}
 		if strings.HasPrefix(line, "Deprecated:") {
 			isDeprecationNote = true
 			isExample = false
 			isNotes = false
+			isReturns = false
+			continue
+		}
+		if strings.HasPrefix(line, "Returns:") {
+			isReturns = true
+			isExample = false
+			isNotes = false
+			isDeprecationNote = false
 			continue
 		}
 
@@ -108,6 +122,8 @@ func extractDescriptionData(doc string) DescriptionData {
 			notesLines = append(notesLines, line)
 		} else if isDeprecationNote {
 			deprecationNoteLines = append(deprecationNoteLines, line)
+		} else if isReturns {
+				returnsLines = append(returnsLines, line)
 		} else {
 			descLines = append(descLines, line)
 		}
@@ -145,11 +161,19 @@ func extractDescriptionData(doc string) DescriptionData {
 		deprecationNote = ""
 	}
 
+	// Returns
+	returns = strings.Join(returnsLines, "</p>\n<p>")
+	returns = "<p>" + returns + "</p>"
+	returns = strings.ReplaceAll(returns, "\t", " ")
+	if returns == "<p></p>" {
+		returns = ""
+
 	return DescriptionData{
 		Description:     description,
 		Example:         example,
 		Notes:           notes,
 		DeprecationNote: deprecationNote,
+		Returns:         returns,
 
 		// Raw fields
 		DescriptionRaw:     descriptionRaw,

--- a/pkg/parser/utils.go
+++ b/pkg/parser/utils.go
@@ -167,7 +167,8 @@ func extractDescriptionData(doc string) DescriptionData {
 	returns = strings.ReplaceAll(returns, "\t", " ")
 	if returns == "<p></p>" {
 		returns = ""
-
+	}
+	
 	return DescriptionData{
 		Description:     description,
 		Example:         example,

--- a/pkg/parser/utils.go
+++ b/pkg/parser/utils.go
@@ -123,7 +123,7 @@ func extractDescriptionData(doc string) DescriptionData {
 		} else if isDeprecationNote {
 			deprecationNoteLines = append(deprecationNoteLines, line)
 		} else if isReturns {
-				returnsLines = append(returnsLines, line)
+			returnsLines = append(returnsLines, line)
 		} else {
 			descLines = append(descLines, line)
 		}
@@ -168,7 +168,7 @@ func extractDescriptionData(doc string) DescriptionData {
 	if returns == "<p></p>" {
 		returns = ""
 	}
-	
+
 	return DescriptionData{
 		Description:     description,
 		Example:         example,
@@ -242,7 +242,8 @@ func findReferences(entity EntityInfo, entityIndex map[string]EntityInfo) []Refe
 
 	// Check for parameters
 	for _, param := range entity.Parameters {
-		paramType := strings.Split(param, " ")[1]
+		parts := strings.Fields(param)
+		paramType := parts[len(parts)-1]
 		if refEntity, found := entityIndex[entity.Package+"."+paramType]; found {
 			references = append(references, ReferenceInfo{
 				Name:        paramType,
@@ -255,9 +256,11 @@ func findReferences(entity EntityInfo, entityIndex map[string]EntityInfo) []Refe
 
 	// Check for returns
 	for _, ret := range entity.Returns {
-		if refEntity, found := entityIndex[entity.Package+"."+ret]; found {
+		parts := strings.Fields(ret)
+		retType := parts[len(parts)-1]
+		if refEntity, found := entityIndex[entity.Package+"."+retType]; found {
 			references = append(references, ReferenceInfo{
-				Name:        ret,
+				Name:        retType,
 				Package:     refEntity.Package,
 				PackageURL:  refEntity.PackageURL,
 				PackagePath: refEntity.PackagePath,


### PR DESCRIPTION
the description extraction utility now can identify and extract "Returns:" from comments in order to make returns descriptions available for parsing as suggested in this https://github.com/Vanilla-OS/Vib/pull/106#issuecomment-2332245963 conversation.

@mirkobrombin please let me know if this disturbs you more than it helps.